### PR TITLE
Update gmm.py

### DIFF
--- a/src/gmm.py
+++ b/src/gmm.py
@@ -79,7 +79,7 @@ class GMM():
         # 5. While the log_likelihood is increasing significantly, or max_iterations has
         # not been reached, continue EM until convergence.
         n_iter = 0
-        while log_likelihood - prev_log_likelihood > 1e-4 and n_iter < self.max_iterations:
+        while abs(log_likelihood - prev_log_likelihood) > 1e-4 and n_iter < self.max_iterations:
             prev_log_likelihood = log_likelihood
 
             assignments = self._e_step(features)


### PR DESCRIPTION
Add abs() to the while loop function. If the difference between log-likelihoods is a big negative number, we can't consider our model to have converged. This fix can prevent tests from failing randomly (see Campuswire 1865) at least in my case.